### PR TITLE
Fix the list of self-closing tags

### DIFF
--- a/index.js
+++ b/index.js
@@ -78,15 +78,19 @@ var singleTag = {
   __proto__: null,
   area: true,
   base: true,
+  // obsolete
   basefont: true,
   br: true,
   col: true,
+  // obsolete
   command: true,
   embed: true,
+  // deprecated
   frame: true,
   hr: true,
   img: true,
   input: true,
+  // deprecated
   isindex: true,
   keygen: true,
   link: true,
@@ -95,8 +99,11 @@ var singleTag = {
   source: true,
   track: true,
   wbr: true,
+};
 
-  //common self closing svg elements
+//common self closing svg elements
+var singleXMLTag = {
+  __proto__: null,
   path: true,
   circle: true,
   ellipse: true,
@@ -140,8 +147,9 @@ function renderTag(elem, opts) {
   }
 
   if (
-    opts.xmlMode &&
-    (!elem.children || elem.children.length === 0)
+    (opts.xmlMode &&
+    (!elem.children || elem.children.length === 0)) ||
+    singleXMLTag[elem.name]
   ) {
     tag += '/>';
   } else {

--- a/index.js
+++ b/index.js
@@ -104,10 +104,11 @@ var singleTag = {
 //common self closing svg elements
 var singleXMLTag = {
   __proto__: null,
-  path: true,
   circle: true,
   ellipse: true,
   line: true,
+  path: true,
+  polygon: true,
   rect: true,
   use: true
 };

--- a/test.js
+++ b/test.js
@@ -101,7 +101,7 @@ function testBody(html) {
   });
 
   it('should render SVG nodes with a closing slash in HTML mode', function() {
-    var str = '<svg><circle x="12" y="12"/><path d="123M"/></svg>';
+    var str = '<svg><circle x="12" y="12"/><path d="123M"/><polygon points="60,20 100,40 100,80 60,100 20,80 20,40"/></svg>';
     expect(html(str)).to.equal(str);
   });
 

--- a/test.js
+++ b/test.js
@@ -100,4 +100,9 @@ function testBody(html) {
     expect(html(str)).to.equal(str);
   });
 
+  it('should render SVG nodes with a closing slash in HTML mode', function() {
+    var str = '<svg><circle x="12" y="12"/><path d="123M"/></svg>';
+    expect(html(str)).to.equal(str);
+  });
+
 }


### PR DESCRIPTION
In HTML, only a few tags can be self-closing: http://www.w3.org/TR/html5/syntax.html#void-elements

Embedded SVG is handled as XML, and the self-closing tags must have the `<name/>` syntax.

This patch special cases a few SVG nodes as being XML-style self-closing.

A few elements in singleTag have been marked as "deprecated" or "obsolete", because they have been removed from the
HTML5 spec. These should probably be removed, and may have been removed from some browsers already.

Note: not implemented is a check that self closing xml tags appear inside of <svg> elements.

Fixes cheeriojs/cheerio#521