### PR TITLE
Remove self closing SVG elements from the single tag list.

### DIFF
--- a/index.js
+++ b/index.js
@@ -95,14 +95,6 @@ var singleTag = {
   source: true,
   track: true,
   wbr: true,
-
-  //common self closing svg elements
-  path: true,
-  circle: true,
-  ellipse: true,
-  line: true,
-  rect: true,
-  use: true
 };
 
 var render = module.exports = function(dom, opts) {


### PR DESCRIPTION
Having these SVG elements in the `singleTag` list cause them not to be closed when `xmlMode` is `false` and thus produce incorrect HTML.
Removing them from the list add a closing tag immediately after these, which make the output HTML correct.

Other possible solutions:
- Make all tags in the `singleTag` list self-closing.
- Have two different lists, one for void elements and one for foreign elements that need to be self-closed.

I chose this solution because I think it's the least likely to break anything ;)
