### PR TITLE
Fix serializer crash when node has no children

### DIFF
--- a/index.js
+++ b/index.js
@@ -138,7 +138,10 @@ function renderTag(elem, opts) {
     tag += '/>';
   } else {
     tag += '>';
-    tag += render(elem.children, opts);
+    
+    if (elem.children) {
+      tag += render(elem.children, opts);
+    }
 
     if (!singleTag[elem.name] || opts.xmlMode) {
       tag += '</' + elem.name + '>';


### PR DESCRIPTION
When node has no children `render()` invokes with `undefined` and cause to exception.
This check helps avoid it.