### PR TITLE
Fix for empty attributes appended with =""

### DIFF
--- a/index.js
+++ b/index.js
@@ -64,7 +64,10 @@ function formatAttrs(attributes, opts) {
     if (!value && booleanAttributes[key]) {
       output += key;
     } else {
-      output += key + '="' + (opts.decodeEntities ? entities.encodeXML(value) : value) + '"';
+      output += key;
+      if (value || opts.xmlMode) {
+        output += '="' + (opts.decodeEntities ? entities.encodeXML(value) : value) + '"';
+      }
     }
   }
 

--- a/test.js
+++ b/test.js
@@ -42,6 +42,11 @@ describe('render', function() {
       var str = '<a> <b> <![CDATA[ asdf&asdf ]]> <c/> <![CDATA[ asdf&asdf ]]> </b> </a>';
       expect(xml(str)).to.equal(str);
     });
+    
+    it('should append ="" to attributes with no value', function() {
+      var str = '<div dropdown-toggle>';
+      expect(xml(str)).to.equal('<div dropdown-toggle=""/>');
+    });    
 
   });
 
@@ -69,6 +74,11 @@ function testBody(html) {
     var str = '<input name="name"/>';
     expect(html(str)).to.equal('<input name="name">');
   });
+  
+  it('should not append ="" to attributes with no value', function() {
+    var str = '<div dropdown-toggle>';
+    expect(html(str)).to.equal('<div dropdown-toggle></div>');
+  });  
 
   it('should render comments correctly', function() {
     var str = '<!-- comment -->';


### PR DESCRIPTION
This commit fixes cheeriojs/cheerio#702
If an attribute has no value, we won't add ="", unless if we're working in XML mode.