### PR TITLE
Wrap `default` in quotes

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ var booleanAttributes = {
   autoplay: true,
   checked: true,
   controls: true,
-  default: true,
+  'default': true,
   defer: true,
   disabled: true,
   hidden: true,


### PR DESCRIPTION
Without the quotes, this breaks when used in old engines (such as implemented in the Android 2.3 browser.)