### PR TITLE
use single quotes for values that contain double quotes

### DIFF
--- a/index.js
+++ b/index.js
@@ -57,6 +57,9 @@ function formatAttrs(attributes, opts) {
   // Loop through the attributes
   for (var key in attributes) {
     value = attributes[key];
+    if (opts.decodeEntities) {
+      value = entities.encodeXML(value);
+    }
     if (output) {
       output += ' ';
     }
@@ -64,7 +67,11 @@ function formatAttrs(attributes, opts) {
     if (!value && booleanAttributes[key]) {
       output += key;
     } else {
-      output += key + '="' + (opts.decodeEntities ? entities.encodeXML(value) : value) + '"';
+      var quote = '"';
+      if (value.indexOf('"') > -1) {
+        quote = '\'';
+      }
+      output += key + '=' + quote + value + quote;
     }
   }
 


### PR DESCRIPTION
This will use single quotes for attributes instead of double quotes, when the value contains double quotes.

Fix for https://github.com/cheeriojs/cheerio/issues/720
