### PR TITLE
New option xmlModeTag to white-list tag names for use in xmlMode

### DIFF
--- a/index.js
+++ b/index.js
@@ -129,14 +129,15 @@ function renderTag(elem, opts) {
   if (elem.name === "svg") opts = {decodeEntities: opts.decodeEntities, xmlMode: true};
 
   var tag = '<' + elem.name,
-      attribs = formatAttrs(elem.attribs, opts);
+      attribs = formatAttrs(elem.attribs, opts),
+      xmlMode = opts.xmlMode && (!opts.xmlModeTag || opts.xmlModeTag[elem.name]);
 
   if (attribs) {
     tag += ' ' + attribs;
   }
 
   if (
-    opts.xmlMode
+    xmlMode
     && (!elem.children || elem.children.length === 0)
   ) {
     tag += '/>';
@@ -146,7 +147,7 @@ function renderTag(elem, opts) {
       tag += render(elem.children, opts);
     }
 
-    if (!singleTag[elem.name] || opts.xmlMode) {
+    if (!singleTag[elem.name] || xmlMode) {
       tag += '</' + elem.name + '>';
     }
   }


### PR DESCRIPTION
Use case: Customize the output from `$().html()` to only use self-closing tags for a specified set of element names. 