### PR TITLE
Use entities.escape instead of entities.encodeXML

### DIFF
--- a/index.js
+++ b/index.js
@@ -64,7 +64,7 @@ function formatAttrs(attributes, opts) {
     if (!value && booleanAttributes[key]) {
       output += key;
     } else {
-      output += key + '="' + (opts.decodeEntities ? entities.encodeXML(value) : value) + '"';
+      output += key + '="' + (opts.decodeEntities ? entities.escape(value, true, false, opts.outputUtf8) : value) + '"';
     }
   }
 
@@ -163,7 +163,7 @@ function renderText(elem, opts) {
 
   // if entities weren't decoded, no need to encode them back
   if (opts.decodeEntities && !(elem.parent && elem.parent.name in unencodedElements)) {
-    data = entities.encodeXML(data);
+    data = entities.escape(data, false, false, opts.outputUtf8);
   }
 
   return data;


### PR DESCRIPTION
Use entities.escape instead of entities.encodeXML
Add outputUtf8 option (to fix #26)

This depends on fb55/entities#28.
