### PR TITLE
fix for empty attributes appended with =""

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,35 +4,6 @@
 var ElementType = require('domelementtype');
 var entities = require('entities');
 
-/*
-  Boolean Attributes
-*/
-var booleanAttributes = {
-  __proto__: null,
-  allowfullscreen: true,
-  async: true,
-  autofocus: true,
-  autoplay: true,
-  checked: true,
-  controls: true,
-  'default': true,
-  defer: true,
-  disabled: true,
-  hidden: true,
-  ismap: true,
-  loop: true,
-  multiple: true,
-  muted: true,
-  open: true,
-  readonly: true,
-  required: true,
-  reversed: true,
-  scoped: true,
-  seamless: true,
-  selected: true,
-  typemustmatch: true
-};
-
 var unencodedElements = {
   __proto__: null,
   style: true,
@@ -62,7 +33,7 @@ function formatAttrs(attributes, opts) {
     }
 
     output += key;
-    if ((value !== null && value !== '') || (opts.xmlMode && !booleanAttributes[key])) {
+    if ((value !== null && value !== '') || opts.xmlMode) {
         output += '="' + (opts.decodeEntities ? entities.encodeXML(value) : value) + '"';
     }
   }

--- a/index.js
+++ b/index.js
@@ -61,10 +61,9 @@ function formatAttrs(attributes, opts) {
       output += ' ';
     }
 
-    if (!value && booleanAttributes[key]) {
-      output += key;
-    } else {
-      output += key + '="' + (opts.decodeEntities ? entities.encodeXML(value) : value) + '"';
+    output += key;
+    if ((value !== null && value !== '') || (opts.xmlMode && !booleanAttributes[key])) {
+        output += '="' + (opts.decodeEntities ? entities.encodeXML(value) : value) + '"';
     }
   }
 

--- a/test.js
+++ b/test.js
@@ -43,6 +43,11 @@ describe('render', function() {
       expect(xml(str)).to.equal(str);
     });
 
+    it('should append ="" to attributes with no value', function() {
+      var str = '<div dropdown-toggle>';
+      expect(xml(str)).to.equal('<div dropdown-toggle=""/>');
+    });
+
   });
 
 });
@@ -68,6 +73,11 @@ function testBody(html) {
   it('should not shorten the "name" attribute when it contains the value "name"', function() {
     var str = '<input name="name"/>';
     expect(html(str)).to.equal('<input name="name">');
+  });
+
+  it('should not append ="" to attributes with no value', function() {
+    var str = '<div dropdown-toggle>';
+    expect(html(str)).to.equal('<div dropdown-toggle></div>');
   });
 
   it('should render comments correctly', function() {

--- a/test.js
+++ b/test.js
@@ -48,6 +48,11 @@ describe('render', function() {
       expect(xml(str)).to.equal('<div dropdown-toggle=""/>');
     });
 
+    it('should append ="" to boolean attributes with no value', function() {
+      var str = '<input disabled>';
+      expect(xml(str)).to.equal('<input disabled=""/>');
+    });
+
   });
 
 });


### PR DESCRIPTION
This PR fixes cheeriojs/cheerio#702 as request in the issue.
If an attribute has no value, we won't add ="", unless if we're working in XML mode.

It should address all concerns raised in PR #23 .