### PR TITLE
add explicit empty attribute flag

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,7 +33,7 @@ function formatAttrs(attributes, opts) {
     }
 
     output += key;
-    if ((value !== null && value !== '') || opts.xmlMode) {
+    if ((value !== null && value !== '') || opts.xmlMode || opts.emptyAttrs) {
         output += '="' + (opts.decodeEntities ? entities.encodeXML(value) : value) + '"';
     }
   }


### PR DESCRIPTION
This adds a configuration option, `emptyAttrs` to forces ```attr=""``` style empty attributes.

https://github.com/cheeriojs/dom-serializer/pull/44 did this but only in `xmlMode`. `xmlMode` does more than just change attribute behavior, hence this option.

See also: https://github.com/cheeriojs/cheerio/issues/702 which has more on this issue.