### PR TITLE
Always escape < in text regardless of decodeEntities

### DIFF
--- a/index.js
+++ b/index.js
@@ -163,12 +163,15 @@ function renderDirective(elem) {
 function renderText(elem, opts) {
   var data = elem.data || '';
 
-  // if entities weren't decoded, no need to encode them back
-  if (
-    opts.decodeEntities &&
-    !(elem.parent && elem.parent.name in unencodedElements)
-  ) {
-    data = entities.encodeXML(data);
+  if (!(elem.parent && elem.parent.name in unencodedElements)) {
+    if (opts.decodeEntities) {
+      data = entities.encodeXML(data);
+    } else {
+      // If entities weren't decoded, no need to encode them back.
+      // Nevertheless let's escape `<` as it's able to sneak in unescaped,
+      // see https://github.com/fb55/htmlparser2/issues/105
+      data = data.replace(/</g, '&lt;');
+    }
   }
 
   return data;

--- a/test.js
+++ b/test.js
@@ -168,4 +168,20 @@ function testBody(html) {
     var str = '<iframe src="test"></iframe>';
     expect(html(str)).to.equal(str);
   });
+
+  it('should always (regardless of decodeEntities) escape < in text nodes', function() {
+    // from https://github.com/fb55/htmlparser2/issues/105
+    var str = '<<img src="javascript:evil"/>img src="javascript:evil"/>';
+    expect(html(str)).to.match(/^&lt;<img src="/);
+  });
+
+  it('should not escape < in scripts', function() {
+    var str = '<script>console.log(a<b)</script>';
+    expect(html(str)).to.equal(str);
+  });
+
+  it('should always (regardless of decodeEntities) escape double quotes in attributes', function() {
+    var str = '<img alt="double quote: &quot;" title=\'double quote: "\'>';
+    expect(html(str)).to.equal('<img alt="double quote: &quot;" title="double quote: &quot;">');
+  });
 }


### PR DESCRIPTION
Motivation: to avoid issues like https://github.com/fb55/htmlparser2/issues/105

Closes #26