### PR TITLE
Fixed HTML symbols escaping bug.

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,6 +42,18 @@ function formatAttrs(attributes, opts) {
 }
 
 /*
+  Escape special symbols in HTML.
+*/
+function escapeHTML(str) {
+  return str
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;");
+}
+
+/*
   Self-enclosing tags (stolen from node-htmlparser)
 */
 var singleTag = {
@@ -131,9 +143,17 @@ function renderDirective(elem) {
 function renderText(elem, opts) {
   var data = elem.data || '';
 
-  // if entities weren't decoded, no need to encode them back
-  if (opts.decodeEntities && !(elem.parent && elem.parent.name in unencodedElements)) {
-    data = entities.encodeXML(data);
+  if (!(elem.parent && elem.parent.name in unencodedElements)) {
+    // When cheerio reading (decoding) input, it will unescape symbols
+    // like `&lt` to `<` in innerHTML, no matter whether `decodeEntities`
+    // is `true` or `false`.
+    if (opts.decodeEntities) {
+      // `entities.encodeXML()` will do escape so we won't escape.
+      data = entities.encodeXML(data);
+    } else {
+      // We need to escape by ourselves.
+      data = escapeHTML(data)
+    }
   }
 
   return data;


### PR DESCRIPTION
Fixed this <https://github.com/cheeriojs/cheerio/issues/1198>.

`cheerio` always un-escape `&lt;`, `&gt`, `&amp;`, `&quot;`, `&apos` back into `<`, `>`, `&`, `"`, `'` when processing input, and it relies on `dom-serializer` to re-escape them when using `html()` method.

If `decodeEntities: true`, `dom-serializer` relies on `entities.encodeXML()` to do re-escape, but it also encode chars like Chinese, Japanese into entities, which is hard for further JavaScript processing if we get webpage content with `html()`.

So most people use `decodeEntities: false` to keep Chinese chars, however then `dom-serializer` forgets to re-escape `<`, `>`, `&`, `"`, `'`, this PR fix this problem.