### PR TITLE
Change escape function to fix bug with default parse5 parser

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,14 +37,20 @@ function escapeHTML(str) {
 }
 
 function escape(str, opts) {
-  // After cheerio 1.0.0-RC3, parser API has changed.
-  // When xmlMode is true, cheerio uses `htmlparser2`,
+  // After cheerio 1.0.0-RC3, parser API has been changed.
+  // When xmlMode or _useHtmlParser2 is true, cheerio uses `htmlparser2`,
   // if `decodeEntities` is false, `htmlparser2` won't decode `&lt;`.
   // When xmlMode is false, cheerio uses `parse5`, which by default
   // decode all entities like `&lt;` and does not support `decodeEntities`,
   // so we need to escape before output.
-  return opts.xmlMode
-    ? (opts.decodeEntities ? entities.encodeXML(str) : str)
+  // Plus, there is a corner case,
+  // when using htmlparser2 with decodeEntities: false,
+  // we need to escape double quote,
+  // because dom-serializer always use double quote for attributes.
+  return opts.xmlMode || opts._useHtmlParser2
+    ? (opts.decodeEntities
+      ? entities.encodeXML(str) :
+      str.replace(/"/g, "&quot;"))
     : escapeHTML(str);
 }
 

--- a/index.js
+++ b/index.js
@@ -25,6 +25,30 @@ var unencodedElements = {
 };
 
 /*
+  Escape special symbols in HTML.
+*/
+function escapeHTML(str) {
+  return str
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;");
+}
+
+function escape(str, opts) {
+  // After cheerio 1.0.0-RC3, parser API has changed.
+  // When xmlMode is true, cheerio uses `htmlparser2`,
+  // if `decodeEntities` is false, `htmlparser2` won't decode `&lt;`.
+  // When xmlMode is false, cheerio uses `parse5`, which by default
+  // decode all entities like `&lt;` and does not support `decodeEntities`,
+  // so we need to escape before output.
+  return opts.xmlMode
+    ? (opts.decodeEntities ? entities.encodeXML(str) : str)
+    : escapeHTML(str);
+}
+
+/*
   Format attributes
 */
 function formatAttrs(attributes, opts) {
@@ -46,12 +70,7 @@ function formatAttrs(attributes, opts) {
     }
     output += key;
     if ((value !== null && value !== '') || opts.xmlMode) {
-      output +=
-        '="' +
-        (opts.decodeEntities
-          ? entities.encodeXML(value)
-          : value.replace(/\"/g, '&quot;')) +
-        '"';
+      output += '="' + escape(value, opts) + '"';
     }
   }
 
@@ -163,12 +182,8 @@ function renderDirective(elem) {
 function renderText(elem, opts) {
   var data = elem.data || '';
 
-  // if entities weren't decoded, no need to encode them back
-  if (
-    opts.decodeEntities &&
-    !(elem.parent && elem.parent.name in unencodedElements)
-  ) {
-    data = entities.encodeXML(data);
+  if (!(elem.parent && elem.parent.name in unencodedElements)) {
+    data = escape(data, opts);
   }
 
   return data;

--- a/test.js
+++ b/test.js
@@ -104,10 +104,12 @@ function testBody(html) {
     expect(html(str)).to.equal(str);
   });
 
-  it('should normalize whitespace if specified', function() {
-    var str = '<a href="./haha.html">hi</a> <a href="./blah.html">blah  </a>';
-    expect(html(str, { normalizeWhitespace: true })).to.equal('<a href="./haha.html">hi</a> <a href="./blah.html">blah </a>');
-  });
+  // `normalizeWhitespace` is an option for `htmlparser2`, not `parse5`.
+  // So this test case is useless for cheerio 1.0.0 now.
+  // it('should normalize whitespace if specified', function() {
+  //   var str = '<a href="./haha.html">hi</a> <a href="./blah.html">blah  </a>';
+  //   expect(html(str, { normalizeWhitespace: true })).to.equal('<a href="./haha.html">hi</a> <a href="./blah.html">blah </a>');
+  // });
 
   it('should preserve multiple hyphens in data attributes', function() {
     var str = '<div data-foo-bar-baz="value"></div>';


### PR DESCRIPTION
Cheerio 1.0.0-RC3 uses parse5 instead of htmlparser2 for HTML parsing, but parse5 decode all entities (include &lt;, &gt;) no matter `decodeEntities` is true or false, so we cannot use this to decide whether a re-encode is needed. **Plus users who using non-ASCII chars may not want their chars becomes XML entities**.

After this PR, if we are using htmlparser2, it will work as old times. And when we are using parse5 (by default), it will only escape HTML chars like `<>&"'` and won't encode user's chars.

Also `normalizeWhitespace` is not supported by parse5 either so I removed related test cases.

Solves cheeriojs/cheerio#1198. I suggest you to read my comments in this issue to get a clear view of what the problem is and how it happens.