### PR TITLE
Remove setting of __proto__

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,8 +9,6 @@ var entities = require('entities');
    https://html.spec.whatwg.org/multipage/parsing.html#parsing-main-inforeign
 */
 var foreignNames = require('./foreignNames.json');
-foreignNames.elementNames.__proto__ = null; /* use as a simple dictionary */
-foreignNames.attributeNames.__proto__ = null;
 
 var unencodedElements = {
   __proto__: null,


### PR DESCRIPTION
Object.prototype.proto is deprecated and it's not clear why it is set to null.

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/proto