### PR TITLE
fix: Do not skip encoding entities for tags when in xmlMode

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -203,6 +203,11 @@ function testBody(html: (input: string, opts?: CheerioOptions) => string) {
     expect(html(str)).toStrictEqual(str);
   });
 
+  it("should not encode tags in script tag", () => {
+    const str = '<script>"<br>"</script>';
+    expect(html(str)).toStrictEqual(str);
+  });
+
   it("should not encode json data", () => {
     const str =
       '<script>var json = {"simple_value": "value", "value_with_tokens": "&quot;here & \'there\'&quot;"};</script>';

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -87,6 +87,17 @@ describe("render DOM parsed with htmlparser2", () => {
       const str = '<svg viewBox="0 0 8 8"><radialGradient/></svg>';
       expect(xml(str)).toStrictEqual(str);
     });
+
+    it("should encode entities in otherwise special tags", () => {
+      expect(xml('<script>"<br/>"</script>')).toStrictEqual(
+        "<script>&quot;<br/>&quot;</script>"
+      );
+    });
+
+    it("should not encode entities if disabled", () => {
+      const str = '<script>"<br/>"</script>';
+      expect(xml(str, { decodeEntities: false })).toStrictEqual(str);
+    });
   });
 });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -203,7 +203,11 @@ function renderText(elem: DataNode, opts: DomSerializerOptions) {
   // If entities weren't decoded, no need to encode them back
   if (
     opts.decodeEntities !== false &&
-    !(elem.parent && unencodedElements.has((elem.parent as Element).name))
+    !(
+      !opts.xmlMode &&
+      elem.parent &&
+      unencodedElements.has((elem.parent as Element).name)
+    )
   ) {
     data = encodeXML(data);
   }


### PR DESCRIPTION
Fixes #281