### PR TITLE
Fix readme typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,9 +63,9 @@ Print self-closing tags for tags without contents.
 
 **`default`** xmlMode
 
-**`example`** With <code>emptyAttrs: false</code>: <code>&lt;foo&gt;&lt;/foo&gt;</code>
+**`example`** With <code>selfClosingTags: false</code>: <code>&lt;foo&gt;&lt;/foo&gt;</code>
 
-**`example`** With <code>emptyAttrs: true</code>: <code>&lt;foo /&gt;</code>
+**`example`** With <code>selfClosingTags: true</code>: <code>&lt;foo /&gt;</code>
 
 ---
 


### PR DESCRIPTION
It seems like somebody copy pasted a section of the readme and forgot to change the names of the config option so I fixed that.