### PR TITLE
test: Add regression test for XSS via missing attribute escaping

### DIFF
--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -260,4 +260,9 @@ function testBody(html: (input: string, opts?: CheerioOptions) => string) {
     const str = '<iframe src="test"></iframe>';
     expect(html(str)).toStrictEqual(str);
   });
+
+  it("should encode double quotes in attribute", () => {
+    const str = `<img src="/" alt='title" onerror="alert(1)" label="x'>`;
+    expect(html(str)).toStrictEqual('<img src="/" alt="title&quot; onerror=&quot;alert(1)&quot; label=&quot;x">');
+  });
 }


### PR DESCRIPTION
Adding unit test for escaping of double quotes in attribute value to avoid regression and potential XSS. 

I was recently doing root cause analysis for a security incident that was caused by issue in dom-serializer@0.1.1. The issue is known and has been fixed in newer versions. This PR adds unit test for this particular case to avoid accidental regression in the future. 