### PR TITLE
feat: Add `encodeEntities` option with `utf8` output

### DIFF
--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -44,6 +44,13 @@ describe("render DOM parsed with htmlparser2", () => {
         '<hr class="an &quot;edge&quot; case">'
       );
     });
+
+    it("should escape entities by default", () => {
+      const str = '<a href="a < b &quot; & c">& " &lt; &gt;</a>';
+      expect(htmlFunc(str)).toStrictEqual(
+        '<a href="a < b &quot; &amp; c">&amp; " &lt; &gt;</a>'
+      );
+    });
   });
 
   // Run html with default options

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -1,17 +1,13 @@
 import cheerio from "cheerio";
 import parse from "cheerio/lib/parse";
-import render from "./index";
+import render, { DomSerializerOptions } from "./index";
 // TODO: We need to temporarily override the Document type
 import type { Document } from "domhandler";
 
 const defaultOpts = cheerio.prototype.options;
 
-interface CheerioOptions {
+interface CheerioOptions extends DomSerializerOptions {
   _useHtmlParser2?: boolean;
-  normalizeWhitespace?: boolean;
-  decodeEntities?: boolean;
-  emptyAttrs?: boolean;
-  selfClosingTags?: boolean;
 }
 
 function html(
@@ -45,11 +41,11 @@ describe("render DOM parsed with htmlparser2", () => {
       );
     });
 
-    it("should escape entities by default", () => {
+    it("should escape entities to utf8 if requested", () => {
       const str = '<a href="a < b &quot; & c">& " &lt; &gt;</a>';
-      expect(htmlFunc(str)).toStrictEqual(
-        '<a href="a < b &quot; &amp; c">&amp; " &lt; &gt;</a>'
-      );
+      expect(
+        html({ _useHtmlParser2: true, encodeEntities: "utf8" }, str)
+      ).toStrictEqual('<a href="a < b &quot; &amp; c">&amp; " &lt; &gt;</a>');
     });
   });
 
@@ -192,13 +188,6 @@ function testBody(html: (input: string, opts?: CheerioOptions) => string) {
   it("should render whitespace by default", () => {
     const str = '<a href="./haha.html">hi</a> <a href="./blah.html">blah</a>';
     expect(html(str)).toStrictEqual(str);
-  });
-
-  it("should normalize whitespace if specified", () => {
-    const str = '<a href="./haha.html">hi</a> <a href="./blah.html">blah  </a>';
-    expect(html(str, { normalizeWhitespace: true })).toStrictEqual(
-      '<a href="./haha.html">hi</a> <a href="./blah.html">blah </a>'
-    );
   });
 
   it("should preserve multiple hyphens in data attributes", () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,7 +48,7 @@ export interface DomSerializerOptions {
   /**
    * Encode characters that are either reserved in HTML or XML.
    *
-   * If the value is `'ascii'`, characters outside of the ASCII range will be encoded as well.
+   * If `xmlMode` is `true` or the value is `'ascii'`, characters outside of the ASCII range will be encoded as well.
    *
    * @default `decodeEntities`
    */
@@ -88,7 +88,7 @@ function formatAttributes(
   const encode =
     (opts.encodeEntities ?? opts.decodeEntities) === false
       ? replaceQuotes
-      : opts.encodeEntities === "ascii"
+      : opts.xmlMode || opts.encodeEntities === "ascii"
       ? encodeXML
       : escapeAttribute;
 
@@ -259,7 +259,10 @@ function renderText(elem: Text, opts: DomSerializerOptions) {
       unencodedElements.has((elem.parent as Element).name)
     )
   ) {
-    data = opts.encodeEntities === "ascii" ? encodeXML(data) : escapeText(data);
+    data =
+      opts.xmlMode || opts.encodeEntities === "ascii"
+        ? encodeXML(data)
+        : escapeText(data);
   }
 
   return data;

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ import type {
   Text,
   CDATA,
 } from "domhandler";
-import { encodeXML } from "entities";
+import { encodeXML, escapeAttribute, escapeText } from "entities";
 
 /**
  * Mixed-case SVG and MathML tags & attributes
@@ -46,7 +46,15 @@ export interface DomSerializerOptions {
    */
   xmlMode?: boolean | "foreign";
   /**
-   * Encode characters that are either reserved in HTML or XML, or are outside of the ASCII range.
+   * Encode characters that are either reserved in HTML or XML.
+   *
+   * If the value is `'ascii'`, characters outside of the ASCII range will be encoded as well.
+   *
+   * @default `decodeEntities`
+   */
+  encodeEntities?: boolean | "ascii";
+  /**
+   * Option inherited from parsing; will lead to entities being encoded.
    *
    * @default true
    */
@@ -64,6 +72,10 @@ const unencodedElements = new Set([
   "noscript",
 ]);
 
+function replaceQuotes(value: string): string {
+  return value.replace(/"/g, "&quot;");
+}
+
 /**
  * Format attributes
  */
@@ -72,6 +84,13 @@ function formatAttributes(
   opts: DomSerializerOptions
 ) {
   if (!attributes) return;
+
+  const encode =
+    (opts.encodeEntities ?? opts.decodeEntities) === false
+      ? replaceQuotes
+      : opts.encodeEntities === "ascii"
+      ? encodeXML
+      : escapeAttribute;
 
   return Object.keys(attributes)
     .map((key) => {
@@ -86,11 +105,7 @@ function formatAttributes(
         return key;
       }
 
-      return `${key}="${
-        opts.decodeEntities !== false
-          ? encodeXML(value)
-          : value.replace(/"/g, "&quot;")
-      }"`;
+      return `${key}="${encode(value)}"`;
     })
     .join(" ");
 }
@@ -237,14 +252,14 @@ function renderText(elem: Text, opts: DomSerializerOptions) {
 
   // If entities weren't decoded, no need to encode them back
   if (
-    opts.decodeEntities !== false &&
+    (opts.encodeEntities ?? opts.decodeEntities) !== false &&
     !(
       !opts.xmlMode &&
       elem.parent &&
       unencodedElements.has((elem.parent as Element).name)
     )
   ) {
-    data = encodeXML(data);
+    data = opts.encodeEntities === "ascii" ? encodeXML(data) : escapeText(data);
   }
 
   return data;

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,11 +48,11 @@ export interface DomSerializerOptions {
   /**
    * Encode characters that are either reserved in HTML or XML.
    *
-   * If `xmlMode` is `true` or the value is `'ascii'`, characters outside of the ASCII range will be encoded as well.
+   * If `xmlMode` is `true` or the value not `'utf8'`, characters outside of the utf8 range will be encoded as well.
    *
    * @default `decodeEntities`
    */
-  encodeEntities?: boolean | "ascii";
+  encodeEntities?: boolean | "utf8";
   /**
    * Option inherited from parsing; will lead to entities being encoded.
    *
@@ -88,7 +88,7 @@ function formatAttributes(
   const encode =
     (opts.encodeEntities ?? opts.decodeEntities) === false
       ? replaceQuotes
-      : opts.xmlMode || opts.encodeEntities === "ascii"
+      : opts.xmlMode || opts.encodeEntities !== "utf8"
       ? encodeXML
       : escapeAttribute;
 
@@ -260,7 +260,7 @@ function renderText(elem: Text, opts: DomSerializerOptions) {
     )
   ) {
     data =
-      opts.xmlMode || opts.encodeEntities === "ascii"
+      opts.xmlMode || opts.encodeEntities !== "utf8"
         ? encodeXML(data)
         : escapeText(data);
   }


### PR DESCRIPTION
Fixes #612