### PR TITLE
fix: respect `encodeEntities: "utf8"` and ensure correct output with `encodeEntities: false`

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,11 +33,11 @@ Can be thought of as the equivalent of the `outerHTML` of the passed node(s).
 
 ### `encodeEntities`
 
-• `Optional` **decodeEntities**: _boolean | "utf8"_
+• `Optional` **encodeEntities**: _boolean | "utf8"_
 
 Encode characters that are either reserved in HTML or XML.
 
-If `xmlMode` is `true` or the value not `'utf8'`, characters outside of the utf8 range will be encoded as well.
+If `xmlMode` is `true` and the value is not `'utf8'`, characters with more than one UTF-8 byte (i.e. characters outside of the ASCII range) will be encoded as well.
 
 **`default`** `decodeEntities`
 

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -4,7 +4,7 @@ import render from "./index";
 interface LoadingOptions extends CheerioOptions {
   _useHtmlParser2?: boolean;
   decodeEntities?: boolean;
-  encodeEntities?: "utf8";
+  encodeEntities?: boolean | "utf8";
   selfClosingTags?: boolean;
   emptyAttrs?: boolean;
 }
@@ -265,3 +265,59 @@ function testBody(html: (input: string, opts?: LoadingOptions) => string) {
     );
   });
 }
+
+describe("should respect options for encoding Unicode chars", () => {
+  type EncodeEntitiesOption = boolean | "utf8" | undefined;
+  interface TestConfig {
+    fn: (str: string, options?: LoadingOptions) => string;
+    shouldEncodeWith: EncodeEntitiesOption[];
+    shouldNotEncodeWith: EncodeEntitiesOption[];
+  }
+
+  const testConfigs: Record<"xml" | "html", TestConfig> = {
+    xml: {
+      fn: xml,
+      shouldEncodeWith: [true, false, undefined],
+      shouldNotEncodeWith: ["utf8"],
+    },
+    html: {
+      fn: html.bind(null, { _useHtmlParser2: true }),
+      shouldEncodeWith: [true],
+      shouldNotEncodeWith: ["utf8", undefined, false],
+    },
+  };
+
+  for (const mode of ["xml", "html"] as const) {
+    describe(`(${mode})`, () => {
+      const { fn, shouldEncodeWith, shouldNotEncodeWith } = testConfigs[mode];
+
+      const unencoded = "ÿ💩";
+      const encoded = "&#xff;&#x1f4a9;";
+      const input = `${unencoded} ${encoded}`;
+
+      for (const encodeEntities of shouldEncodeWith) {
+        it(`should encode with ${JSON.stringify({ encodeEntities })}`, () => {
+          const expected = `${encoded} ${encoded}`;
+          expect(fn(input, { encodeEntities })).toStrictEqual(expected);
+        });
+      }
+
+      for (const encodeEntities of shouldNotEncodeWith) {
+        it(`should not encode with ${JSON.stringify({ encodeEntities })}`, () => {
+          const expected = `${unencoded} ${unencoded}`;
+          expect(fn(input, { encodeEntities })).toStrictEqual(expected);
+        });
+      }
+
+      const unchanged = '<x attr="val&quot;">&lt;y&gt;&amp;&lt;/y&gt;</x>';
+      for (const encodeEntities of [
+        ...shouldEncodeWith,
+        ...shouldNotEncodeWith,
+      ]) {
+        it(`should not create or remove elements with ${JSON.stringify({ encodeEntities })}`, () => {
+          expect(fn(unchanged, { encodeEntities })).toStrictEqual(unchanged);
+        });
+      }
+    });
+  }
+});


### PR DESCRIPTION
Once merged and dependency updated, this should fix https://github.com/cheeriojs/cheerio/issues/4437#issuecomment-2958977592.

* `encodeEntities: "utf8"` option now overrides `xmlMode`, which I think was the intended behavior originally (otherwise the option seems to do nothing).
* I've rationalized the name `utf8` as referring to chars with more than one UTF-8 byte (i.e. characters outside of the ASCII range). I still don't think this naming makes much sense but it's arguably better than calling it "unicode mode" or something, which would be even more confusing.
* `encodeEntities: false` can no longer create new elements or malformed output (i.e. serializing input of `&lt;` gives `&lt;`, not `<`)

The matrix for encoding "💩" now looks like this:

`encodeEntities` | XML mode | HTML mode
-|-|-
`true` | `&#x1f4a9;` | `&#x1f4a9;`
`false` | `&#x1f4a9;` | `💩`
`"utf8"` | `💩` | `💩`
`undefined` | `&#x1f4a9;` | `💩`