### PR TITLE
docs: Add thread model, document `encodeEntities: false` caveat

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,11 +33,13 @@ Can be thought of as the equivalent of the `outerHTML` of the passed node(s).
 
 ### `encodeEntities`
 
-• `Optional` **decodeEntities**: _boolean | "utf8"_
+• `Optional` **encodeEntities**: _boolean | "utf8"_
 
-Encode characters that are either reserved in HTML or XML.
+Encode characters reserved in HTML or XML in text and attribute values.
 
-If `xmlMode` is `true` or the value not `'utf8'`, characters outside of the ASCII range will be encoded as well.
+If `xmlMode` is `true` or the value is not `'utf8'`, characters outside of the ASCII range will be encoded as well.
+
+> **Security:** Setting this to `false` disables encoding of `<`, `>`, and `&` in text and attribute values. This is intended for the round-trip case where the DOM was parsed with `decodeEntities: false`, so markup characters only exist as entity references. If the DOM contains raw markup characters (e.g., from a default-decoded parse, or from programmatic manipulation), they will be emitted literally — do not use this option with untrusted input unless you have validated the DOM yourself.
 
 **`default`** `decodeEntities`
 
@@ -47,7 +49,7 @@ If `xmlMode` is `true` or the value not `'utf8'`, characters outside of the ASCI
 
 • `Optional` **decodeEntities**: _boolean_
 
-Option inherited from parsing; will be used as the default value for `encodeEntities`.
+Default for `encodeEntities`. Named to match the parser option of the same name so a single options object can be threaded through parse and serialize. Despite the name, on the serializer this option controls *encoding* — setting it to `false` carries the same security caveat as `encodeEntities: false`.
 
 **`default`** true
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,6 +4,34 @@
 
 Only the last published version is supported.
 
+## Threat Model
+
+`dom-serializer` is a non-validating serializer. It turns a [domhandler](https://github.com/fb55/domhandler) DOM tree into a string and is the inverse of a parser such as [htmlparser2](https://github.com/fb55/htmlparser2). The library's contract is:
+
+> Given a DOM constructed within the syntactic bounds a parser produces, serialization yields HTML/XML that round-trips to an equivalent DOM.
+
+What this means in practice:
+
+- **Text content and attribute values are encoded** by default. These are the channels through which untrusted content typically flows, and the serializer treats them as untrusted.
+- **Structural fields are trusted to be syntactically valid** and are emitted verbatim. This includes:
+  - element tag names (`Element.name`)
+  - attribute names (keys of `Element.attribs`)
+  - comment data (`Comment.data`)
+  - directive / doctype / processing-instruction data (`ProcessingInstruction.data`)
+  - CDATA section contents
+
+  A parser cannot produce values in these fields that would break the surrounding syntax — for example, `htmlparser2` terminates a comment at `-->`, a CDATA section at `]]>`, and an attribute name at whitespace, `=`, `/`, or `>`, so those sequences cannot appear in parser-produced data. The serializer relies on this and does not re-validate.
+
+- **Round-trip safety holds for any input parsed by `htmlparser2`** under default options. The output, when re-parsed, yields a DOM equivalent to the input.
+
+## Out of Scope
+
+The following are not considered vulnerabilities in `dom-serializer`:
+
+1. **Programmatic DOM construction with attacker-controlled structural fields.** If application code assigns untrusted strings to `Element.name`, attribute keys, `Comment.data`, etc., the serializer will faithfully emit them. This is analogous to assigning untrusted strings to `element.innerHTML` in a browser — the unsafety is at the construction boundary, not the serialization boundary. Validation of structural fields is the responsibility of whatever code populates them.
+
+2. **Use of `encodeEntities: false` or `decodeEntities: false` with a DOM containing raw markup characters in text or attribute values.** These options exist for the round-trip case (parsing with `decodeEntities: false` to preserve entity references, then serializing without re-encoding them) and are documented as such. If your DOM contains raw `<`, `>`, or `&` in text or attribute values and you disable encoding, the output will contain those characters literally. See the option documentation for details.
+
 ## Reporting a Vulnerability
 
 To report a security vulnerability,


### PR DESCRIPTION
To help guide security reports