### PR TITLE
chore: use HTTPS repository URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git://github.com/cheeriojs/dom-serializer.git"
+    "url": "https://github.com/cheeriojs/dom-serializer.git"
   },
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
Updates the package repository metadata to use HTTPS instead of the unauthenticated `git://` protocol.

Validation:
- `git diff --check`
- parsed the changed `package.json` file(s) with Node.js